### PR TITLE
feat: ✨ SSL 인증 경로 추가 (#15)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     image: jwilder/nginx-proxy
     ports:
       - 80:80
+      - 443:443
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /path/to/certs:/etc/nginx/certs
 
   # gateway-service:
   #   build:


### PR DESCRIPTION
## 💭 개요 
- #15 

## 💻️ 작업사항
- 가비아로 서브 도메인 연결 후 secure sign으로 SSL 인증서 발급 후 서버에 적용 

## 💡 주의 사항
-  `/path/to/certs`에 인증서 파일 추가해야 함! 